### PR TITLE
chore: bump to latest dev release & document new setting

### DIFF
--- a/config/flexconnect.config.toml
+++ b/config/flexconnect.config.toml
@@ -7,3 +7,14 @@
 functions = [
     "flexconnect.sample_function"
 ]
+
+# When FlexConnect invokes a function in response to GetFlightInfo call from the
+# clients, it will give the invocation a deadline to complete. If the deadline
+# is exceeded, the GetFlightInfo will fail with TIMEOUT and the function invocation
+# will be cancelled.
+#
+# You can use this setting to specify the deadline in milliseconds. The value must
+# be a positive number. It is not possible to disable the deadline.
+#
+# Default value is 180 000 millis (3minutes).
+# call_deadline_ms = 180000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-gooddata-flight-server==1.30.1.dev2
-gooddata-flexconnect==1.30.1.dev2
+gooddata-flight-server==1.32.3.dev2
+gooddata-flexconnect==1.32.3.dev2
 
 pyarrow
 structlog


### PR DESCRIPTION
- the latest version fixes a discrepancy & hardcoded nature of the call invocation deadline
- this value was hardcoded to 60secs which is not aligned with the standard deadline (3min) of GoodData product
- the latest version changes the default deadline to 3 minutes and allows to change the default using `call_deadline_ms` setting
- this new setting is now added & documented within the flexconnect.config.toml. it is commented out on purpose.

JIRA: CQ-1005